### PR TITLE
Fixed an issue causing the packages workflow to fail

### DIFF
--- a/.github/workflows/deploy-packages.yaml
+++ b/.github/workflows/deploy-packages.yaml
@@ -1,7 +1,7 @@
 name: Publish package to GitHub Packages
 on:
   release:
-    types: [created]
+    types: [ created ]
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -18,6 +18,7 @@ jobs:
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        run: chmod +x ./gradlew
         with:
           arguments: publish
         env:

--- a/.github/workflows/deploy-packages.yaml
+++ b/.github/workflows/deploy-packages.yaml
@@ -14,11 +14,12 @@ jobs:
         with:
           java-version: '18'
           distribution: 'adopt'
+      - name: Run CHMOD to make gradlew executable
+        run: chmod +x ./gradlew
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
-        run: chmod +x ./gradlew
         with:
           arguments: publish
         env:


### PR DESCRIPTION
The packages workflow was failing due to ./gradlew not being executable. This pull request addresses that issue.